### PR TITLE
Deduplicate shared OpenAPI schemas

### DIFF
--- a/common/openapi/common-schemas.yaml
+++ b/common/openapi/common-schemas.yaml
@@ -50,6 +50,33 @@ components:
         - $ref: '#/components/schemas/Id'
         - $ref: '#/components/schemas/ProductBase'
         - $ref: '#/components/schemas/CreatedOn'
+    ExtendedProductInventory:
+      type: integer
+      minimum: 1
+      maximum: 9999
+    ExtendedProductBase:
+      title: Product Details
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/ProductType'
+        inventory:
+          $ref: '#/components/schemas/ExtendedProductInventory'
+        cost:
+          type: number
+          format: float
+          minimum: 0.01
+      required:
+        - name
+        - type
+        - inventory
+    ExtendedProduct:
+      allOf:
+        - $ref: '#/components/schemas/Id'
+        - $ref: '#/components/schemas/ExtendedProductBase'
+        - $ref: '#/components/schemas/CreatedOn'
     OrderBase:
       title: Order Details
       type: object
@@ -61,6 +88,13 @@ components:
       required:
         - productid
         - count
+    FulfilledOrderStatus:
+      type: string
+      title: OrderStatus
+      enum:
+        - fulfilled
+        - pending
+        - cancelled
     Order:
       allOf:
         - $ref: '#/components/schemas/Id'
@@ -119,6 +153,19 @@ components:
           type: string
         value:
           type: string
+    FraudHold:
+      type: object
+      properties:
+        durationInMinutes:
+          type: integer
+          description: Duration of hold in Minutes
+          format: int32
+        autoCloseAction:
+          type: string
+          description: Action to be performed after lapsing DurationInMinutes
+          nullable: true
+      additionalProperties: {}
+      description: Fraud hold details
     BadRequest:
       title: Bad Request
       type: object

--- a/common/openapi/order-api/api_order_v5.yaml
+++ b/common/openapi/order-api/api_order_v5.yaml
@@ -397,14 +397,6 @@ paths:
           $ref: "#/components/responses/NotFound"
 components:
   schemas:
-    OrderStatus:
-      type: string
-      title: OrderStatus
-      enum:
-        - fulfilled
-        - pending
-        - cancelled
-    
     Order:
       allOf:
         - $ref: '../common-schemas.yaml#/components/schemas/Id'
@@ -412,7 +404,7 @@ components:
         - type: object
           properties:
             status:
-              $ref: '#/components/schemas/OrderStatus'
+              $ref: '../common-schemas.yaml#/components/schemas/FulfilledOrderStatus'
           required:
             - status
 
@@ -422,7 +414,7 @@ components:
         - type: object
           properties:
             status:
-              $ref: '#/components/schemas/OrderStatus'
+              $ref: '../common-schemas.yaml#/components/schemas/FulfilledOrderStatus'
           required:
             - status
 
@@ -430,40 +422,27 @@ components:
       type: string
       format: uuid
 
-    ErrorResponseBody:
-      title: Bad Request
-      type: object
-      properties:
-        timestamp:
-          type: string
-        status:
-          type: integer
-        error:
-          type: string
-        message:
-          type: string
-  
   responses:
     NotFound:
       description: "Not Found"
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorResponseBody"
+            $ref: "../common-schemas.yaml#/components/schemas/BadRequest"
 
     BadRequest:
       description: "Bad Request"
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorResponseBody"
+            $ref: "../common-schemas.yaml#/components/schemas/BadRequest"
     
     UnprocessableEntity:
       description: "Unprocessable Entity"
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/ErrorResponseBody"
+            $ref: "../common-schemas.yaml#/components/schemas/BadRequest"
 
   securitySchemes:
     ApiKeyAuth:

--- a/openapi/order-bff-resiliency/product_search_bff_v6.yaml
+++ b/openapi/order-bff-resiliency/product_search_bff_v6.yaml
@@ -132,27 +132,4 @@ paths:
               schema:
                 $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/BadRequest'
   /monitor/{id}:
-    get:
-      description: Retrieves a Monitor by ID
-      operationId: retrieveMonitor
-      tags:
-        - Monitor
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-      responses:
-        '200':
-          description: Monitor status
-          content:
-            application/json:
-              schema:
-                $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/MonitorResponse'
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/BadRequest'
+    $ref: '../../common/openapi/common-schemas.yaml#/components/pathItems/MonitorById'

--- a/openapi/response-templating/simple-openapi-spec.yaml
+++ b/openapi/response-templating/simple-openapi-spec.yaml
@@ -28,7 +28,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProductBase'
+              $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/ExtendedProductBase'
       responses:
         '201':
           description: Product created
@@ -85,7 +85,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
+                $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/ExtendedProduct'
         '429':
           description: TooManyRequests
           headers:
@@ -155,32 +155,3 @@ paths:
                   $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/Order'
   /monitor/{id}:
     $ref: '../../common/openapi/common-schemas.yaml#/components/pathItems/MonitorById'
-components:
-  schemas:
-    ProductInventory:
-      type: integer
-      minimum: 1
-      maximum: 9999
-    ProductBase:
-      title: Product Details
-      type: object
-      properties:
-        name:
-          type: string
-        type:
-          $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/ProductType'
-        inventory:
-          $ref: '#/components/schemas/ProductInventory'
-        cost:
-          type: number
-          format: float
-          minimum: 0.01
-      required:
-        - name
-        - type
-        - inventory
-    Product:
-      allOf:
-        - $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/Id'
-        - $ref: '#/components/schemas/ProductBase'
-        - $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/CreatedOn'

--- a/openapi/schema-resiliency/simple-openapi-spec.yaml
+++ b/openapi/schema-resiliency/simple-openapi-spec.yaml
@@ -28,7 +28,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProductBase'
+              $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/ExtendedProductBase'
       responses:
         '201':
           description: Product created
@@ -87,7 +87,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Product'
+                  $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/ExtendedProduct'
         '429':
           description: TooManyRequests
           headers:
@@ -157,30 +157,5 @@ paths:
     $ref: '../../common/openapi/common-schemas.yaml#/components/pathItems/MonitorById'
 components:
   schemas:
-    ProductInventory:
-      type: integer
-      minimum: 1
-      maximum: 9999
-    ProductBase:
-      title: Product Details
-      type: object
-      properties:
-        name:
-          type: string
-        type:
-          $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/ProductType'
-        inventory:
-          $ref: '#/components/schemas/ProductInventory'
-        cost:
-          type: number
-          format: float
-          minimum: 0.01
-      required:
-        - name
-        - type
-        - inventory
     Product:
-      allOf:
-        - $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/Id'
-        - $ref: '#/components/schemas/ProductBase'
-        - $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/CreatedOn'
+      $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/ExtendedProduct'

--- a/openapi/security/common.yaml
+++ b/openapi/security/common.yaml
@@ -1,5 +1,7 @@
 components:
   schemas:
+    ProductType:
+      $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/ProductType'
     ProductDetails:
       title: Product Details
       type: object
@@ -7,35 +9,22 @@ components:
         name:
           type: string
         type:
-          $ref: '#/components/schemas/ProductType'
+          $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/ProductType'
         inventory:
           type: integer 
       required:
         - name
         - type
         - inventory
-    ProductType:
-      type: string
-      title: Product Type
-      description: Fixed set of product types
-      enum:
-        - book
-        - food
-        - gadget
-        - other
     ProductId:
-      title: Product Id
-      type: object
-      properties:
-        id:
-          type: integer
-      required:
-        - id
+      $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/Id'
     Product:
       title: Product
       allOf:
         - $ref: '#/components/schemas/ProductId'
         - $ref: '#/components/schemas/ProductDetails'
+    OrderStatus:
+      $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/FulfilledOrderStatus'
     OrderDetails:
       title: Order Details
       description: Order details including product id, count and status
@@ -46,26 +35,13 @@ components:
         count:
           type: integer
         status:
-          $ref: '#/components/schemas/OrderStatus'
+          $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/FulfilledOrderStatus'
       required:
         - productid
         - count
         - status
-    OrderStatus:
-      type: string
-      title: OrderStatus
-      enum:
-        - fulfilled
-        - pending
-        - cancelled
     OrderId:
-      title: Order Id
-      type: object
-      properties:
-        id:
-          type: integer
-      required:
-        - id
+      $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/Id'
     Order:
       title: Order
       allOf:

--- a/openapi/workflow-in-same-spec/tasks.yaml
+++ b/openapi/workflow-in-same-spec/tasks.yaml
@@ -359,7 +359,7 @@ components:
           nullable: true
         hold:
           allOf:
-            - $ref: '#/components/schemas/createTaskFraudHold'
+            - $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/FraudHold'
           description: Fraud hold details - Fraud type tasks only
           nullable: true
         outcome:
@@ -375,19 +375,6 @@ components:
           description: Flag to indicate if customer task creation not required for a verification task
       additionalProperties: { }
       description: Model for Task data type
-    createTaskFraudHold:
-      type: object
-      properties:
-        durationInMinutes:
-          type: integer
-          description: Duration of hold in Minutes
-          format: int32
-        autoCloseAction:
-          type: string
-          description: Action to be performed after lapsing DurationInMinutes
-          nullable: true
-      additionalProperties: { }
-      description: Fraud hold details
     createTaskResponse:
       type: object
       properties:
@@ -417,7 +404,7 @@ components:
           description: State of the task
         hold:
           allOf:
-            - $ref: '#/components/schemas/createTaskFraudHold'
+            - $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/FraudHold'
           description: Fraud hold details
           nullable: true
       additionalProperties: { }
@@ -452,19 +439,6 @@ components:
           description: Associated tasks with the application Id
       additionalProperties: { }
       description: Response model for Create task
-    fraudHold:
-      type: object
-      properties:
-        durationInMinutes:
-          type: integer
-          description: Duration of hold in Minutes
-          format: int32
-        autoCloseAction:
-          type: string
-          description: Action to be performed after lapsing DurationInMinutes
-          nullable: true
-      additionalProperties: { }
-      description: Fraud hold details
     problemDetails:
       type: object
       properties:
@@ -524,7 +498,7 @@ components:
           nullable: true
         hold:
           allOf:
-            - $ref: '#/components/schemas/fraudHold'
+            - $ref: '../../common/openapi/common-schemas.yaml#/components/schemas/FraudHold'
           description: Fraud hold details
           nullable: true
         state:


### PR DESCRIPTION
## Summary
- move duplicated OpenAPI component definitions into `common/openapi/common-schemas.yaml`
- update affected specs to reference the shared schemas and shared monitor path item
- keep compatibility-sensitive local aliases only where Specmatic requires the original component names to remain present

## Validation
- parsed all OpenAPI YAML files with `python3`
- ran `mcp__specmatic__backward_compatibility_check` for `openapi/security`
- ran `mcp__specmatic__backward_compatibility_check` for `openapi/schema-resiliency/simple-openapi-spec.yaml`
- ran `mcp__specmatic__backward_compatibility_check` for the full repo and got 14/14 compatible
