### PR TITLE
Add RBAC with OAuth to order-api-with-auth

### DIFF
--- a/openapi/security/common_response_schema.yaml
+++ b/openapi/security/common_response_schema.yaml
@@ -8,7 +8,7 @@ components:
           type: string
           format: date-time
         status:
-          type: number
+          type: integer
         error:
           type: string
         message:

--- a/openapi/security/common_response_schema.yaml
+++ b/openapi/security/common_response_schema.yaml
@@ -6,7 +6,7 @@ components:
       properties:
         timestamp:
           type: string
-          format: datetime
+          format: date-time
         status:
           type: number
         error:

--- a/openapi/security/common_response_schema.yaml
+++ b/openapi/security/common_response_schema.yaml
@@ -6,6 +6,7 @@ components:
       properties:
         timestamp:
           type: string
+          format: datetime
         status:
           type: number
         error:

--- a/openapi/security/common_responses.yaml
+++ b/openapi/security/common_responses.yaml
@@ -6,3 +6,9 @@ components:
         application/json:
           schema:
             $ref: "./common_response_schema.yaml#/components/schemas/BadRequestErrorResponseBody"
+    Forbidden:
+      description: "Forbidden"
+      content:
+        application/json:
+          schema:
+            $ref: "./common_response_schema.yaml#/components/schemas/BadRequestErrorResponseBody"

--- a/openapi/security/common_responses.yaml
+++ b/openapi/security/common_responses.yaml
@@ -11,7 +11,12 @@ components:
       content:
         application/json:
           schema:
-            $ref: "./common_response_schema.yaml#/components/schemas/BadRequestErrorResponseBody"
+            allOf:
+              - $ref: "./common_response_schema.yaml#/components/schemas/BadRequestErrorResponseBody"
+              - type: object
+                properties:
+                  path:
+                    type: string
     Forbidden:
       description: "Forbidden"
       content:

--- a/openapi/security/common_responses.yaml
+++ b/openapi/security/common_responses.yaml
@@ -6,6 +6,12 @@ components:
         application/json:
           schema:
             $ref: "./common_response_schema.yaml#/components/schemas/BadRequestErrorResponseBody"
+    Unauthorized:
+      description: "Unauthorized"
+      content:
+        application/json:
+          schema:
+            $ref: "./common_response_schema.yaml#/components/schemas/BadRequestErrorResponseBody"
     Forbidden:
       description: "Forbidden"
       content:

--- a/openapi/security/order-api-with-auth.yaml
+++ b/openapi/security/order-api-with-auth.yaml
@@ -13,7 +13,7 @@ paths:
   "/products/{id}":
     parameters:
       - schema:
-          type: number
+          type: integer
         name: id
         in: path
         required: true
@@ -53,7 +53,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponseBody"
+                $ref: "./common_response_schema.yaml#/components/schemas/BadRequestErrorResponseBody"
               examples:
                 INVALID_ID:
                   value:
@@ -287,7 +287,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorResponseBody"
+                $ref: "./common_response_schema.yaml#/components/schemas/BadRequestErrorResponseBody"
               examples:
                 INVALID_ID:
                   value:
@@ -350,18 +350,6 @@ paths:
         - apiKeyAuth: []
 components:
   schemas:
-    ErrorResponseBody:
-      properties:
-        id:
-          type: number
-        timestamp:
-          type: string
-        status:
-          type: number
-        error:
-          type: string
-        message:
-          type: string
   securitySchemes:
     basicAuth:
       type: http

--- a/openapi/security/order-api-with-auth.yaml
+++ b/openapi/security/order-api-with-auth.yaml
@@ -23,8 +23,6 @@ paths:
             value: 10
           INVALID_ID:
             value: "344"
-          UPDATE_DETAILS:
-            value: 10
           DELETE_PRODUCT:
             value: 20
     get:
@@ -77,26 +75,18 @@ paths:
             text/plain:
               schema:
                 type: string
-              examples:
-                UPDATE_DETAILS:
-                  value: "success"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
+        "403":
+          $ref: "./common_responses.yaml#/components/responses/Forbidden"
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: "./common.yaml#/components/schemas/Product"
-            examples:
-              UPDATE_DETAILS:
-                value:
-                  name: "XYZ Fone"
-                  type: "gadget"
-                  inventory: 10
-                  id: 10
       security:
-        - oAuth2AuthCode: []
+        - oAuth2AuthCode: [admins]
     delete:
       summary: Delete a product
       description: Deletes an existing product by its identifier.
@@ -169,8 +159,10 @@ paths:
                 $ref: "./common.yaml#/components/schemas/ProductId"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
+        "403":
+          $ref: "./common_responses.yaml#/components/responses/Forbidden"
       security:
-        - oAuth2AuthCode: []
+        - oAuth2AuthCode: [admins]
   /orders:
     get:
       summary: Search for orders
@@ -227,12 +219,6 @@ paths:
           application/json:
             schema:
               $ref: "./common.yaml#/components/schemas/OrderDetails"
-            examples:
-              CREATE_ORDER:
-                value:
-                  productid: 10
-                  count: 2
-                  status: pending
       responses:
         "200":
           description: POST /orders
@@ -240,14 +226,12 @@ paths:
             application/json:
               schema:
                 $ref: "./common.yaml#/components/schemas/OrderId"
-              examples:
-                CREATE_ORDER:
-                  value:
-                    id: 10
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
+        "403":
+          $ref: "./common_responses.yaml#/components/responses/Forbidden"
       security:
-        - oAuth2AuthCode: []
+        - oAuth2AuthCode: [users]
   "/orders/{id}":
     parameters:
       - schema:
@@ -312,26 +296,18 @@ paths:
             text/plain:
               schema:
                 type: string
-              examples:
-                UPDATE_ORDER:
-                  value: "success"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
+        "403":
+          $ref: "./common_responses.yaml#/components/responses/Forbidden"
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: "./common.yaml#/components/schemas/Order"
-            examples:
-              UPDATE_ORDER:
-                value:
-                  productid: 10
-                  id: 10
-                  count: 1
-                  status: pending
       security:
-        - oAuth2AuthCode: []
+        - oAuth2AuthCode: [users]
     delete:
       summary: Cancel an order
       description: Cancels an existing order by its identifier.
@@ -380,6 +356,8 @@ components:
           tokenUrl: http://localhost:8083/realms/specmatic/protocol/openid-connect/token
           scopes:
             email: email
+            users: users role
+            admins: admins role
     apiKeyAuth:
       type: apiKey
       in: header

--- a/openapi/security/order-api-with-auth.yaml
+++ b/openapi/security/order-api-with-auth.yaml
@@ -44,6 +44,8 @@ paths:
                     type: "gadget"
                     inventory: 10
                     id: 10
+        "401":
+          $ref: "./common_responses.yaml#/components/responses/Unauthorized"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
         "404":
@@ -75,6 +77,8 @@ paths:
             text/plain:
               schema:
                 type: string
+        "401":
+          $ref: "./common_responses.yaml#/components/responses/Unauthorized"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
         "403":
@@ -103,6 +107,8 @@ paths:
               examples:
                 DELETE_PRODUCT:
                   value: "success"
+        "401":
+          $ref: "./common_responses.yaml#/components/responses/Unauthorized"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
       security:
@@ -134,6 +140,8 @@ paths:
                 type: array
                 items:
                   $ref: "./common.yaml#/components/schemas/Product"
+        "401":
+          $ref: "./common_responses.yaml#/components/responses/Unauthorized"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
       security:
@@ -157,6 +165,8 @@ paths:
             application/json:
               schema:
                 $ref: "./common.yaml#/components/schemas/ProductId"
+        "401":
+          $ref: "./common_responses.yaml#/components/responses/Unauthorized"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
         "403":
@@ -185,6 +195,8 @@ paths:
                       count: 2
                       status: "pending"
                       id: 10
+        "401":
+          $ref: "./common_responses.yaml#/components/responses/Unauthorized"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
       parameters:
@@ -226,6 +238,8 @@ paths:
             application/json:
               schema:
                 $ref: "./common.yaml#/components/schemas/OrderId"
+        "401":
+          $ref: "./common_responses.yaml#/components/responses/Unauthorized"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
         "403":
@@ -264,6 +278,8 @@ paths:
                     count: 2
                     status: "pending"
                     id: 10
+        "401":
+          $ref: "./common_responses.yaml#/components/responses/Unauthorized"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
         "404":
@@ -296,6 +312,8 @@ paths:
             text/plain:
               schema:
                 type: string
+        "401":
+          $ref: "./common_responses.yaml#/components/responses/Unauthorized"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
         "403":
@@ -324,6 +342,8 @@ paths:
               examples:
                 DELETE_ORDER:
                   value: "success"
+        "401":
+          $ref: "./common_responses.yaml#/components/responses/Unauthorized"
         "400":
           $ref: "./common_responses.yaml#/components/responses/BadRequest"
       security:


### PR DESCRIPTION
## Summary
This PR adds RBAC to the existing OAuth flow in `order-api-with-auth`.

## Changes
* Added roles/scopes to the existing OAuth security scheme in the specification.
* Added `403` response codes, the application will respond with this when invalid role is used
* Added access rules for two roles:
  * `users` can access order POST endpoints.
  * `admins` can access product  POST endpoints.

