### PR TITLE
Add operation-scoped OAuth and align the order API contract

### DIFF
--- a/openapi/security/order-api-with-auth.yaml
+++ b/openapi/security/order-api-with-auth.yaml
@@ -10,6 +10,19 @@ tags:
 servers:
   - url: "http://localhost:3000"
 paths:
+  /health:
+    get:
+      summary: Health check
+      description: Reports whether the service is available.
+      operationId: get-health
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            text/plain:
+              schema:
+                type: string
+      security: []
   "/products/{id}":
     parameters:
       - schema:
@@ -64,10 +77,10 @@ paths:
       operationId: get-product-id
       security:
         - basicAuth: []
-    post:
+    patch:
       summary: Update product details
       description: Updates an existing product by its identifier.
-      operationId: post-products-id
+      operationId: patch-products-id
       tags:
         - Product
       responses:
@@ -159,7 +172,7 @@ paths:
             schema:
               $ref: "./common.yaml#/components/schemas/ProductDetails"
       responses:
-        "200":
+        "201":
           description: POST /products
           content:
             application/json:
@@ -232,7 +245,7 @@ paths:
             schema:
               $ref: "./common.yaml#/components/schemas/OrderDetails"
       responses:
-        "200":
+        "201":
           description: POST /orders
           content:
             application/json:
@@ -299,10 +312,10 @@ paths:
       parameters: []
       security:
         - basicAuth: []
-    post:
+    patch:
       summary: Update order details
       description: Updates an existing order by its identifier.
-      operationId: post-orders-id
+      operationId: patch-orders-id
       tags:
         - Order
       responses:

--- a/openapi/security/order-api-with-auth.yaml
+++ b/openapi/security/order-api-with-auth.yaml
@@ -103,7 +103,7 @@ paths:
             schema:
               $ref: "./common.yaml#/components/schemas/Product"
       security:
-        - oAuth2AuthCode: [admins]
+        - oAuth2AuthCode: ["product:create"]
     delete:
       summary: Delete a product
       description: Deletes an existing product by its identifier.
@@ -185,7 +185,7 @@ paths:
         "403":
           $ref: "./common_responses.yaml#/components/responses/Forbidden"
       security:
-        - oAuth2AuthCode: [admins]
+        - oAuth2AuthCode: ["product:create"]
   /orders:
     get:
       summary: Search for orders
@@ -258,7 +258,7 @@ paths:
         "403":
           $ref: "./common_responses.yaml#/components/responses/Forbidden"
       security:
-        - oAuth2AuthCode: [users]
+        - oAuth2AuthCode: ["order:create"]
   "/orders/{id}":
     parameters:
       - schema:
@@ -338,7 +338,7 @@ paths:
             schema:
               $ref: "./common.yaml#/components/schemas/Order"
       security:
-        - oAuth2AuthCode: [users]
+        - oAuth2AuthCode: ["order:create"]
     delete:
       summary: Cancel an order
       description: Cancels an existing order by its identifier.
@@ -377,8 +377,8 @@ components:
           tokenUrl: http://localhost:8083/realms/specmatic/protocol/openid-connect/token
           scopes:
             email: email
-            users: users role
-            admins: admins role
+            order:create: Create and update orders
+            product:create: Create and update products
     apiKeyAuth:
       type: apiKey
       in: header


### PR DESCRIPTION
## Summary

- Replace the role-shaped OAuth scopes with the operation scopes `order:create` and `product:create`.
- Apply the appropriate scope to each protected order and product create or update operation.
- Model updates as `PATCH` operations and return `201 Created` from create operations.
- Add an unauthenticated `GET /health` endpoint for service readiness checks.